### PR TITLE
task UpdateCBH: Bug fixed in updating Comment Based Help in functions to point to external help

### DIFF
--- a/ModuleBuild.build.ps1
+++ b/ModuleBuild.build.ps1
@@ -445,14 +445,14 @@ task UpdateCBH {
 "@
 
     $ScratchPath = Join-Path $BuildRoot $Script:BuildEnv.ScratchFolder
-    $CBHPattern = "(?ms)(\<#.*\.SYNOPSIS.*?#>)"
+    [Regex]$CBHPattern = '(?ms)\<\#(\#(?!\>)|[^#])*\#\>'
     Get-ChildItem -Path "$($ScratchPath)\$($Script:BuildEnv.PublicFunctionSource)\*.ps1" -File | ForEach-Object {
         $FormattedOutFile = $_.FullName
         $FileName = $_.Name
         Write-Description White "Replacing CBH in file: $($FileName)" -level 2
         $FunctionName = $FileName -replace '.ps1', ''
         $NewExternalHelp = $ExternalHelp -replace '{{LINK}}', ($Script:BuildEnv.ModuleWebsite + "/tree/master/$($Script:BuildEnv.BaseReleaseFolder)/$($Script:BuildEnv.ModuleVersion)/docs/Functions/$($FunctionName).md")
-        $UpdatedFile = (get-content  $FormattedOutFile -raw) -replace $CBHPattern, $NewExternalHelp
+        $UpdatedFile = $CBHPattern.Replace( (Get-Content  $FormattedOutFile -raw), $NewExternalHelp, 1)
         $UpdatedFile | Out-File -FilePath $FormattedOutFile -force -Encoding $Script:BuildEnv.Encoding
     }
 }

--- a/ModuleBuild.build.ps1
+++ b/ModuleBuild.build.ps1
@@ -10,8 +10,8 @@ param (
 )
 
 Function Write-Description {
-    # Basic indented descriptive build output.
-    param (
+    # Basic indented descriptive build output. $Description can contain Newlines.
+    Param (
         [string]$color = 'White',
         [string]$Description = '',
         [int]$Level = 0,
@@ -22,11 +22,12 @@ Function Write-Description {
     )
 
     $thisindent = (' ' * $indent) * $level
-    if ($accent) {
+    If ($accent) {
         $accentleft = $AccentL
         $accentright = $AccentR
     }
-    Write-Build $color "$accentleft$thisindent$Description$accentright"
+
+    $Description -split '\r\n|\n' | ForEach-Object { Write-Build $color "$accentleft$thisindent$($_)$accentright" }
 }
 
 if (Test-Path $BuildFile) {

--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -9,9 +9,9 @@
     [switch]$Force
 )
 
-# Basic indented descriptive build output.
 Function Write-Description {
-    param (
+    # Basic indented descriptive build output. $Description can contain Newlines.
+    Param (
         [string]$color = 'White',
         [string]$Description = '',
         [int]$Level = 0,
@@ -22,11 +22,12 @@ Function Write-Description {
     )
 
     $thisindent = (' ' * $indent) * $level
-    if ($accent) {
+    If ($accent) {
         $accentleft = $AccentL
         $accentright = $AccentR
     }
-    Write-Build $color "$accentleft$thisindent$Description$accentright"
+
+    $Description -split '\r\n|\n' | ForEach-Object { Write-Build $color "$accentleft$thisindent$($_)$accentright" }
 }
 
 if (Test-Path $BuildFile) {

--- a/release/ModuleBuild/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/release/ModuleBuild/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -9,9 +9,9 @@
     [switch]$Force
 )
 
-# Basic indented descriptive build output.
 Function Write-Description {
-    param (
+    # Basic indented descriptive build output. $Description can contain Newlines.
+    Param (
         [string]$color = 'White',
         [string]$Description = '',
         [int]$Level = 0,
@@ -22,11 +22,12 @@ Function Write-Description {
     )
 
     $thisindent = (' ' * $indent) * $level
-    if ($accent) {
+    If ($accent) {
         $accentleft = $AccentL
         $accentright = $AccentR
     }
-    Write-Build $color "$accentleft$thisindent$Description$accentright"
+
+    $Description -split '\r\n|\n' | ForEach-Object { Write-Build $color "$accentleft$thisindent$($_)$accentright" }
 }
 
 if (Test-Path $BuildFile) {


### PR DESCRIPTION
The Issue: If we have multiple <# … #> Comments like the following situation, then everything between the first <# and the last #> was replaced by the single one external help link:
```
Function Set-FileContent-Encoded() {
	<#
	.SYNOPSIS
		…
	#>
	[CmdletBinding()]
	Param (
		…
	)

	Function ConvertHashtableTo-Object {
		<#
		.SYNOPSIS
			…
		#>
		…
	}
}
```
The Fix:
- only affects this file
- recognizes multiple Comment Based Help texts `<# … #>` correctly ***and replaces only the first found Comment Based Help texts with the link to the external help.***

