### PR TITLE
Version increment enhancements

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,18 +1,95 @@
 #Requires -Version 5
+
+<#
+    .SYNOPSIS
+        Invokes the process to build a PowerShell Module
+
+    .DESCRIPTION
+	    This Script belongs to the PowerShell Module 'ModuleBuild' from Zachary Loeber (zloeber), see https://github.com/zloeber/ModuleBuild
+
+	    The Build Tasks are defined in <MyModuleName>.build.ps1
+    
+    .PARAMETER BuildModule
+       	Invokes the default build Task defined by a dot (task . …) in <MyModuleName>.build.ps1
+    
+    .PARAMETER UploadPSGallery
+    	Invokes this command: Invoke-Build -Task PublishPSGallery
+	    It pushes the current release to the PS Script Gallery:
+	    Gallery: https://www.powershellgallery.com/
+	    Man:     https://docs.microsoft.com/en-us/powershell/gallery/readme
+    
+    .PARAMETER InstallAndTestModule
+    	Invokes this command: Invoke-Build -Task InstallAndTestModule
+    	Assigned main tasks:
+    	- InstallModule: Install the new built module to the local machine
+    	- TestInstalledModule: Calls Import-Module for the new built module
+    
+    .PARAMETER NewVersion
+	    Invokes this command: Invoke-Build -Task UpdateVersion -NewVersion $NewVersion -ReleaseNotes $ReleaseNotes
+	    Assigned main tasks:
+	    - NewVersion: Set the new version to the module
+	    - UpdateRelease: Updates the current module manifest with the ReleaseNotes 
+                         and the version defined in the build config file (if they differ)
+    
+    .PARAMETER IncrementVersion
+        ValidateSet: Major, Minor, Patch, Build
+        This Parameter defines which part of a semantic versioning (see: https://semver.org/)
+        should be automatically incremented: 
+
+        Argument      <Major>.<Minor>.<Patch>.<Build>
+        Major           ++       0       0      0
+        Minor          Keep     ++       0      0
+        Patch          Keep    Keep     ++      0
+        Build          Keep    Keep    Keep    ++
+    
+    .PARAMETER ShowVersion
+        Invokes this command: Invoke-Build -Task ShowVersion
+    
+    .PARAMETER ReleaseNotes
+    	Invokes this command: Invoke-Build -Task UpdateVersion -NewVersion $NewVersion -ReleaseNotes $ReleaseNotes
+    	Assigned main tasks: See Parameter NewVersion
+
+    .PARAMETER InsertCBH
+    	Invokes this command: Invoke-Build -Task InsertMissingCBH
+    	Assigned main tasks:
+    	- UpdateCBHtoScratch: Update public functions to include a template comment based help.
+    
+    .PARAMETER ForceInstallModule
+	    If a 3rd party Module need to be installed, then Install-Module will use -Force
+
+    .EXAMPLE
+        PS C:\> .\Build.ps1
+        Builds the Module in the current directory
+
+    .NOTES
+    	Original Conecpt & Idea: Zachary Loeber (zloeber)
+    	ModuleBuild, see https://github.com/zloeber/ModuleBuild
+	    A scaffolding framework which can be used to kickstart a generic PowerShell module project.
+#>
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCmdletCorrectly', '')]
 [CmdletBinding(DefaultParameterSetName = 'Build')]
 param (
     [parameter(Position = 0, ParameterSetName = 'Build')]
     [switch]$BuildModule,
-    [parameter(Position = 2, ParameterSetName = 'Build')]
+    [parameter(Position = 1, ParameterSetName = 'Build')]
     [switch]$UploadPSGallery,
-    [parameter(Position = 3, ParameterSetName = 'Build')]
+    [parameter(Position = 2, ParameterSetName = 'Build')]
+    [Alias(InstallAndImportModule)]
     [switch]$InstallAndTestModule,
-    [parameter(Position = 4, ParameterSetName = 'Build')]
+    [parameter(Position = 3, ParameterSetName = 'Build')]
     [version]$NewVersion,
+    [parameter(Position = 4, ParameterSetName = 'Build')]
+    [ValidateSet('Major', 'Minor', 'Patch', 'Build', IgnoreCase)]
+    [string]$IncrementVersion,
+    [parameter(ParameterSetName = 'Build')]
+    [switch]$ShowVersion,
     [parameter(Position = 5, ParameterSetName = 'Build')]
     [string]$ReleaseNotes,
-    [parameter(Position = 6, ParameterSetName = 'CBH')]
-    [switch]$InsertCBH
+    [parameter(Position = 0, ParameterSetName = 'CBH')]
+    [switch]$InsertCBH,
+    [parameter(Position = 6, ParameterSetName = 'Build')]
+    [parameter(Position = 1, ParameterSetName = 'CBH')]
+    [switch]$ForceInstallModule
 )
 
 function PrerequisitesLoaded {
@@ -20,7 +97,8 @@ function PrerequisitesLoaded {
     try {
         if ((get-module InvokeBuild -ListAvailable) -eq $null) {
             Write-Output "Attempting to install the InvokeBuild module..."
-            $null = Install-Module InvokeBuild -Scope:CurrentUser
+            $Splat = @{ Force = ($script:ForceInstallModule.IsPresent -and $script:ForceInstallModule) }
+            $null = Install-Module InvokeBuild -Scope:CurrentUser @Splat
         }
         if (get-module InvokeBuild -ListAvailable) {
             Write-Output -NoNewLine "Importing InvokeBuild module"
@@ -38,6 +116,8 @@ function PrerequisitesLoaded {
 }
 
 function CleanUp {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '')]
+    Param ()
     try {
         Write-Output ''
         Write-Output 'Attempting to clean up the session (loaded modules and such)...'
@@ -73,6 +153,20 @@ switch ($psCmdlet.ParameterSetName) {
                 throw $_
             }
         }
+        
+        If ($NewVersion -ne $null -or
+            $IncrementVersion -ne $null) {
+            Try {
+                Invoke-Build -Task UpdateVersion -NewVersion $NewVersion -ReleaseNotes $ReleaseNotes -IncrementVersion:$IncrementVersion
+            } Catch {
+                Throw $_
+            }
+        }
+        
+        If ($ShowVersion) {
+            Invoke-Build -Task ShowVersion
+        }
+        
         # If no parameters were specified or the build action was manually specified then kick off a standard build
         if (($psboundparameters.count -eq 0) -or ($BuildModule)) {
             try {

--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -1,12 +1,62 @@
-﻿param (
+﻿<#
+    .SYNOPSIS
+        This Script will is called by Invoke-Build and builds the Project
+    
+    .DESCRIPTION
+    	Invoke-Build is a Build and test automation in PowerShell Module from Roman Kuzmin
+	    See: https://github.com/nightroman/Invoke-Build
+    
+    .PARAMETER BuildEnvironmentFile
+    	Optional: The file which contains the Build Environment
+        Default: build\*.buildenvironment.ps1
+    
+    .PARAMETER NewVersion
+    	Optional: the new Module Version, e.g. 0.0.0.1
+    
+    .PARAMETER ReleaseNotes
+    	Optional: if ReleaseNotes are available, then the ModuleManifest is updated
+    
+    .PARAMETER IncrementVersion
+	    If defined, then the Version will be incremented
+        ValidateSet: Major, Minor, Patch, Build
+
+        The Argument defines which part of a semantic versioning (see: https://semver.org/)
+        should be automatically incremented: 
+
+        Argument      <Major>.<Minor>.<Patch>.<Build>
+        Major           ++       0       0      0
+        Minor          Keep     ++       0      0
+        Patch          Keep    Keep     ++      0
+        Build          Keep    Keep    Keep    ++
+
+	
+        Comparison of terms:
+        	Semantic Versioning | Microsoft [Version]
+        	Major               | Major
+        	Minor               | Minor
+        	Patch               | Build
+        	Build               | Revision
+    
+    .EXAMPLE
+        PS C:\> .\<Modulename>.build.ps1
+    
+    .NOTES
+        Additional information about the file.
+#>
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param (
     [parameter(Position = 0)]
-    [string]$BuildFile = @(Get-ChildItem 'build\*.buildenvironment.ps1')[0].FullName,
+    [string]$BuildEnvironmentFile = @(Get-ChildItem 'build\*.buildenvironment.ps1')[0].FullName,
     [parameter(Position = 1)]
     [version]$NewVersion = $null,
     [parameter(Position = 2)]
     [string]$ReleaseNotes,
     [parameter(Position = 3)]
-    [switch]$Force
+    [switch]$Force,
+    [parameter(Position = 4)]
+    [ValidateSet('Major', 'Minor', 'Patch', 'Build', IgnoreCase)]
+    [string]$IncrementVersion
 )
 
 Function Write-Description {
@@ -30,8 +80,8 @@ Function Write-Description {
     $Description -split '\r\n|\n' | ForEach-Object { Write-Build $color "$accentleft$thisindent$($_)$accentright" }
 }
 
-if (Test-Path $BuildFile) {
-    . $BuildFile
+if (Test-Path $BuildEnvironmentFile) {
+    . $BuildEnvironmentFile
 }
 else {
     throw "Without a build environment file we are at a loss as to what to do!"
@@ -68,6 +118,7 @@ task LoadRequiredModules {
     if ($Script:BuildEnv.OptionCodeHealthReport) {
         $RequiredModules += 'PSCodeHealth'
     }
+    
     $Script:RequiredModules | Foreach-Object {
         if ((get-module $_ -ListAvailable) -eq $null) {
             Write-Description White "Installing $($_) Module" -Level 2
@@ -188,6 +239,28 @@ task NewVersion LoadBuildTools, LoadModuleManifest, {
     $ReleasePath = Join-Path $BuildRoot $Script:BuildEnv.BaseReleaseFolder
     $AllReleases = @((Get-ChildItem $ReleasePath -Directory | Where-Object {$_.Name -match '^([0-9].[0-9].[0-9])$'} | Select-Object).Name | ForEach-Object {[version]$_})
 
+    # Automatic Version increment?
+    If ($IncrementVersion -ne $null) {
+        # Increment the actual ModuleVersion
+        $CurrentVersion = [version]$Script:BuildEnv.ModuleVersion
+        Switch ($IncrementVersion) {
+            'Major' {
+                $NewVersion = "{0}.{1}.{2}.{3}" -f (($CurrentVersion.Major + 1), 0, 0, 0)
+            }
+            'Minor' {
+                $NewVersion = "{0}.{1}.{2}.{3}" -f ($CurrentVersion.Major, ($CurrentVersion.Minor + 1), 0, 0)
+            }
+            'Patch' {
+                $NewVersion = "{0}.{1}.{2}.{3}" -f ($CurrentVersion.Major, $CurrentVersion.Minor, ($CurrentVersion.Build + 1), 0)
+            }
+            'Build' {
+                $NewVersion = "{0}.{1}.{2}.{3}" -f ($CurrentVersion.Major, $CurrentVersion.Minor, $CurrentVersion.Build, ($CurrentVersion.Revision + 1))
+            }
+        }
+        
+        Write-Description White "Changing Version from $($CurrentVersion) to $($NewVersion)" -level 2
+    }
+    
     # if a new version wasn't passed as a parameter then prompt for one
     if ($null -eq $NewVersion) {
         do {
@@ -449,14 +522,14 @@ task UpdateCBH {
 "@
 
     $ScratchPath = Join-Path $BuildRoot $Script:BuildEnv.ScratchFolder
-    $CBHPattern = "(?ms)(\<#.*\.SYNOPSIS.*?#>)"
+    [Regex]$CBHPattern = '(?ms)\<\#(\#(?!\>)|[^#])*\#\>'
     Get-ChildItem -Path "$($ScratchPath)\$($Script:BuildEnv.PublicFunctionSource)\*.ps1" -File | ForEach-Object {
         $FormattedOutFile = $_.FullName
         $FileName = $_.Name
         Write-Description White "Replacing CBH in file: $($FileName)" -level 2
         $FunctionName = $FileName -replace '.ps1', ''
         $NewExternalHelp = $ExternalHelp -replace '{{LINK}}', ($Script:BuildEnv.ModuleWebsite + "/tree/master/$($Script:BuildEnv.BaseReleaseFolder)/$($Script:BuildEnv.ModuleVersion)/docs/Functions/$($FunctionName).md")
-        $UpdatedFile = (get-content  $FormattedOutFile -raw) -replace $CBHPattern, $NewExternalHelp
+        $UpdatedFile = $CBHPattern.Replace( (Get-Content  $FormattedOutFile -raw), $NewExternalHelp, 1)
         $UpdatedFile | Out-File -FilePath $FormattedOutFile -force -Encoding $Script:BuildEnv.Encoding
     }
 }
@@ -879,7 +952,13 @@ task GithubPush VersionCheck, {
     assert (-not $changes) "Please, commit changes."
 }
 
+# Synopsis: Display the current version
+task DisplayVersion {
+    Write-Description White "The current Version is: $($Script:BuildEnv.ModuleVersion)" -level 2
+}
+
 # Synopsis: Build the module
+# '.' is the default Build Task which is called if no explicit Task to execute is declared
 task . Configure, CodeHealthReport, Clean, PrepareStage, GetPublicFunctions, SanitizeCode, CreateHelp, CreateModulePSM1, CreateModuleManifest, AnalyzeModuleRelease, PushVersionRelease, PushCurrentRelease, CreateProjectHelp, PostBuildTasks, BuildSessionCleanup
 
 # Synopsis: Install and test load the module.
@@ -893,3 +972,6 @@ task BuildInstallTestAndPublishModule Configure, CodeHealthReport, Clean, Prepar
 
 # Synopsis: Instert Comment Based Help where it doesn't already exist (output to scratch directory)
 task InsertMissingCBH Configure, Clean, UpdateCBHtoScratch, BuildSessionCleanup
+
+# Synopsis: Display the current version
+task ShowVersion DisplayVersion


### PR DESCRIPTION
Hi Zachary

Thank you for your answer a few days ago, so I'll start with a few small contributions.

Please feel completely free to reject ideas and suggestions. Usually, I'm straightforward... I guess :-).

### Warning: there are differences between ModuleBuild.build.ps1 and it's template
In `plaster/ModuleBuild/scaffold/modulename.build.template`, there are some small deltas which I can't merge because I don't know the background.

### Overview

- I've added some parameters and a small task to simplify to update the Version
- I've added PowerShell Script comments to help users find information where they're probably looking for it first (after they have studied the web-help)

### The Details:

#### `Build.ps1`
```
- Tried to add a Script PowerShell Description (.Synopsis, .Description, etc.)
- Script param():
  - Fixed the Position Numbers (based on ParameterSet)
  - Parameter InstallAndTestModule:
    - Added the Alias InstallAndImportModule because InstallAndTestModule does not Test the Module but it calls Import-Module. Therefore, this is more precise.
  - New Parameter: IncrementVersion
    ValidateSet: Major, Minor, Patch, Build
    The Argument defines which part of a semantic versioning (see: https://semver.org/)
    should be automatically incremented: 
      Argument      <Major>.<Minor>.<Patch>.<Build>
      Major           ++       0       0      0
      Minor          Keep     ++       0      0
      Patch          Keep    Keep     ++      0
      Build          Keep    Keep    Keep    ++
  - New Parameter: ShowVersion
    I added this switch *and* a build task ShowVersion so that the version number can be displayed.
  - New Parameter: ForceInstallModule
    Maybe, we could use -Force
	 The idea: It is used to allow the Build Process to install any necessary Module without asking the user. This is useful to fire and forget the Build task, especially if it will be used on a Build Server :-)
- I have testet ModuleBuild using PSScriptAnalyzer and therefore I have added one or more [Diagnostics.CodeAnalysis.SuppressMessageAttribute] statements
```

#### `ModuleBuild.build.ps1`
```
- Script param():
  - BuildFile
   I hope it is OK that I have renamed the Parameter BuildFile to $BuildEnvironmentFile, because it reference the BuildEnvironment File. (In the ModuleBuild context, I expected a real BuildFile in Variable called BuildFile)
  - New Parameter: IncrementVersion with [ValidateSet('Major', 'Minor', 'Patch', 'Build', IgnoreCase)]
    Using e.g. -IncrementVersion Minor
- task NewVersion
  - Added to logic to increment the Version based on -IncrementVersion
- New task
  - # Synopsis: Display the current version
    task DisplayVersion { }
```

#### `plaster/ModuleBuild/scaffold/modulename.build.template`
Merged changes from ModuleBuild.build.ps1

Important: in this template, there are still old differences which I can not merge because I don't know the background
