### PR TITLE
Solved issue wit the creation of the ModulePage 

### DIFF
--- a/plaster/ModuleBuild/scaffold/Build.template
+++ b/plaster/ModuleBuild/scaffold/Build.template
@@ -12,7 +12,7 @@ param (
     [parameter(Position = 5, ParameterSetName = 'Build')]
     [string]$ReleaseNotes,
     [parameter(Position = 6, ParameterSetName = 'CBH')]
-    [switch]$AddCBH
+    [switch]$AddMissingCBH
 )
 
 function PrerequisitesLoaded {

--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -503,20 +503,15 @@ task CreateMarkdownHelp GetPublicFunctions, {
 
     # Create the function .md files and the generic module page md as well for the distributable module
     $null = New-MarkdownHelp -module $Script:BuildEnv.ModuleToBuild -OutputFolder "$($StageReleasePath)\docs\" -Force -WithModulePage -Locale 'en-US' -FwLink $FwLink -HelpVersion $Script:BuildEnv.ModuleVersion -Encoding ([System.Text.Encoding]::($Script:BuildEnv.Encoding))
+    $null = Update-MarkdownHelpModule -Path "$($StageReleasePath)\docs\" -Force -RefreshModulePage
     <#
      Replace each missing element we need for a proper generic module page .md file
      Also replace the blank Guid 00000000-0000-0000-0000-000000000000 with the actual module guid
      (PlatyPS won't know what this is as our module in memory is loaded from the psm1 file not the actual manifest file)
     #>
     $ModulePageFileContent = Get-Content -raw $ModulePage
-    $ModulePageFileContent = $ModulePageFileContent -replace '{{Manually Enter Description Here}}', $Script:Manifest.Description
-    $Script:FunctionsToExport | Foreach-Object {
-        Write-Description White "Updating definition for the following function: $($_)" -Level 2
-        $TextToReplace = "{{Manually Enter $($_) Description Here}}"
-        $ReplacementText = (Get-Help -Detailed $_).Synopsis
-        $ModulePageFileContent = $ModulePageFileContent -replace $TextToReplace, $ReplacementText `
+    $ModulePageFileContent = $ModulePageFileContent -replace '{{ Fill in the Description }}', $Script:Manifest.Description
                                   -replace '00000000-0000-0000-0000-000000000000', ($Script:Manifest.Guid).ToString()
-    }
     $ModulePageFileContent | Out-File $ModulePage -Force -Encoding $Script:BuildEnv.Encoding
     $MissingDocumentation = Select-String -Path "$($StageReleasePath)\docs\*.md" -Pattern "({{.*}})"
 

--- a/plaster/ModuleBuild/scaffold/modulename.build.template
+++ b/plaster/ModuleBuild/scaffold/modulename.build.template
@@ -510,7 +510,7 @@ task CreateMarkdownHelp GetPublicFunctions, {
      (PlatyPS won't know what this is as our module in memory is loaded from the psm1 file not the actual manifest file)
     #>
     $ModulePageFileContent = Get-Content -raw $ModulePage
-    $ModulePageFileContent = $ModulePageFileContent -replace '{{ Fill in the Description }}', $Script:Manifest.Description
+    $ModulePageFileContent = $ModulePageFileContent -replace '{{ Fill in the Description }}', $Script:Manifest.Description `
                                   -replace '00000000-0000-0000-0000-000000000000', ($Script:Manifest.Guid).ToString()
     $ModulePageFileContent | Out-File $ModulePage -Force -Encoding $Script:BuildEnv.Encoding
     $MissingDocumentation = Select-String -Path "$($StageReleasePath)\docs\*.md" -Pattern "({{.*}})"


### PR DESCRIPTION
This change corrects the generation of the 'ModulePage' markdown page

I assume the placeholder text inserted by PlatyPS had changed over time and did not correspond anymore with the one in ModuleBuild.
I also used the PlatyPS Update-MarkdownHelpModule function to update the function description.